### PR TITLE
Store language selection in localStorage

### DIFF
--- a/ui/src/components/Navigation/LanguageSelect.tsx
+++ b/ui/src/components/Navigation/LanguageSelect.tsx
@@ -27,11 +27,16 @@ const LanguageOptionButton = ({
   lng,
   label
 }: {
-  lng: string
+  lng: 'fi' | 'sv' | 'en'
   label: string
 }) => {
   const { i18n } = useTranslation()
   const isActiveLang = (lng: string): boolean => i18n.language === lng
+
+  const handleChangeLanguage = () => {
+    i18n.changeLanguage(lng)
+    localStorage.setItem('i18nextLng', lng)
+  }
 
   return (
     <MenuItem
@@ -40,7 +45,7 @@ const LanguageOptionButton = ({
       fontWeight={isActiveLang(lng) ? 'semibold' : 'initial'}
       color={isActiveLang(lng) ? '#1876f2' : 'initial'}
       disabled={isActiveLang(lng)}
-      onClick={() => i18n.changeLanguage(lng)}>
+      onClick={handleChangeLanguage}>
       {label}
     </MenuItem>
   )

--- a/ui/src/i18n.tsx
+++ b/ui/src/i18n.tsx
@@ -15,7 +15,6 @@ i18n
   // init i18next
   // for all options read: https://www.i18next.com/overview/configuration-options
   .init({
-    lng: 'fi',
     fallbackLng: 'fi',
     debug: true,
     keySeparator: '.',


### PR DESCRIPTION
## Description

Use the previously selected language on page load. 

## This PR contains

- [ ] New feature(s)
- [x] Bug fixes
- [ ] Refactoring
- [ ] New/updated documentation
- [ ] Incomplete functionality

## PR checklist

- [x] I have reviewed the changes myself
- [ ] I have added relevant tests

## How to test

Change language to English or Swedish, reload page, it should not change language back to Finnish.
